### PR TITLE
chore: update conftest.py to use platform file extension

### DIFF
--- a/go/validation/tests/conftest.py
+++ b/go/validation/tests/conftest.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import adbc_drivers_validation.model
 import pytest
@@ -44,5 +44,6 @@ def driver_path(driver: adbc_drivers_validation.model.DriverQuirks) -> str:
     }.get(sys.platform, "so")
     # Assume shared library is in the repo root
     return str(
-        Path(__file__).parent.parent.parent / f"build/libadbc_driver_{driver.name}.{ext}"
+        Path(__file__).parent.parent.parent
+        / f"build/libadbc_driver_{driver.name}.{ext}"
     )


### PR DESCRIPTION
## What's Changed

Updates conftest.py to use the correct file extension for the platform the tests are being run on.