### PR TITLE
docs: update note with link to adbc-quickstarts

### DIFF
--- a/go/docs/mysql.md
+++ b/go/docs/mysql.md
@@ -46,7 +46,7 @@ conn = dbapi.connect(
 )
 ```
 
-Note: The example above is for Python using the [adbc-driver-manager](https://pypi.org/project/adbc-driver-manager) package but the process will be similar for other driver managers.
+Note: The example above is for Python using the [adbc-driver-manager](https://pypi.org/project/adbc-driver-manager) package but the process will be similar for other driver managers. See [adbc-quickstarts](https://github.com/columnar-tech/adbc-quickstarts).
 
 ### Connection String Format
 


### PR DESCRIPTION
This upstreams a change I made in https://github.com/adbc-drivers/docs.adbc-drivers.org/pull/57/ to add a quickstarts link under the Python example in the MySQL driver docs, as already exists for some of the other driver docs.