### PR TITLE
feat: set info code for SqlIdentifierQuoteChar

### DIFF
--- a/go/mysql.go
+++ b/go/mysql.go
@@ -305,9 +305,9 @@ func NewDriver(alloc memory.Allocator) adbc.Driver {
 		WithConnectionFactory(&mysqlConnectionFactory{}).
 		WithErrorInspector(MySQLErrorInspector{})
 	driver.DriverInfo.MustRegister(map[adbc.InfoCode]any{
-		adbc.InfoDriverName:             "ADBC Driver Foundry Driver for MySQL",
-		adbc.InfoVendorSql:              true,
-		adbc.InfoVendorSubstrait:        false,
+		adbc.InfoDriverName:                       "ADBC Driver Foundry Driver for MySQL",
+		adbc.InfoVendorSql:                        true,
+		adbc.InfoVendorSubstrait:                  false,
 		adbc.InfoCode(infoSqlIdentifierQuoteChar): "`",
 	})
 

--- a/go/mysql.go
+++ b/go/mysql.go
@@ -290,6 +290,10 @@ func (f *mysqlConnectionFactory) CreateConnection(
 	}, nil
 }
 
+// infoSqlIdentifierQuoteChar is the Flight SQL GetSqlInfo code for
+// SQL_IDENTIFIER_QUOTE_CHAR, in the [500, 1000) XDBC range reserved by ADBC.
+const infoSqlIdentifierQuoteChar = 504
+
 // NewDriver constructs the ADBC Driver for "mysql".
 func NewDriver(alloc memory.Allocator) adbc.Driver {
 	vendorName := "MySQL"
@@ -301,9 +305,10 @@ func NewDriver(alloc memory.Allocator) adbc.Driver {
 		WithConnectionFactory(&mysqlConnectionFactory{}).
 		WithErrorInspector(MySQLErrorInspector{})
 	driver.DriverInfo.MustRegister(map[adbc.InfoCode]any{
-		adbc.InfoDriverName:      "ADBC Driver Foundry Driver for MySQL",
-		adbc.InfoVendorSql:       true,
-		adbc.InfoVendorSubstrait: false,
+		adbc.InfoDriverName:             "ADBC Driver Foundry Driver for MySQL",
+		adbc.InfoVendorSql:              true,
+		adbc.InfoVendorSubstrait:        false,
+		adbc.InfoCode(infoSqlIdentifierQuoteChar): "`",
 	})
 
 	return driver

--- a/go/mysql_test.go
+++ b/go/mysql_test.go
@@ -267,6 +267,8 @@ func (q *MySQLQuirks) GetMetadata(code adbc.InfoCode) interface{} {
 		return true
 	case adbc.InfoVendorSubstrait:
 		return false
+	case adbc.InfoCode(504): // SQL_IDENTIFIER_QUOTE_CHAR
+		return "`"
 	}
 	return nil
 }


### PR DESCRIPTION
sets info code for SqlIdentifierQuoteChar to a backtick.

P.S. should constants be defined in driverbase instead?