### PR TITLE
fix: disable idle connection pooling to prevent MySQL max_connections exhaustion

### DIFF
--- a/go/db_factory.go
+++ b/go/db_factory.go
@@ -49,7 +49,12 @@ func (f *MySQLDBFactory) CreateDB(ctx context.Context, driverName string, opts m
 		return nil, err
 	}
 
-	return sql.Open(driverName, dsn)
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxIdleConns(0)
+	return db, nil
 }
 
 // forceUTCTimezone parses the DSN and overrides the time_zone and loc parameters to UTC


### PR DESCRIPTION

## Summary

When the driver creates short-lived ADBC databases (e.g., per-query in an analytical engine like StarRocks), the default `sql.DB` pool behavior of keeping idle connections exhausts the MySQL server's `max_connections`.

## Problem

`db_factory.go` returns `sql.Open()` directly, which creates pools with Go's default `MaxIdleConns=2`. Under rapid per-query database create/destroy cycles (132 operations in ~5 minutes with TPC-H SF1), each pool retains 1-2 idle MySQL connections in `Sleep` state. These idle connections survive `sql.DB.Close()` async shutdown, causing cumulative exhaustion of `max_connections` with:

```
Error 1040: Too many connections: BE:10001
```

Bisect data: connections climb linearly (1 → 7 → 11 → 15 → 18 → 23 → 39) with each ADBC operation.

## Fix

Set `db.SetMaxIdleConns(0)` in `CreateDB` immediately after `sql.Open()`:

```diff
-   return sql.Open(driverName, dsn)
+   db, err := sql.Open(driverName, dsn)
+   if err != nil {
+       return nil, err
+   }
+   db.SetMaxIdleConns(0)
+   return db, nil
```

## Verification

- 22-query TPC-H SF1 benchmark at `--runs 3` (132 ADBC operations): zero connection errors
- Post-fix connection count: stable at 3 regardless of operation count (previously accumulated +4 per run)
- No regression in query correctness

Closes #100