### PR TITLE
test(go): upgrade to MySQL 9.7 and enable OpenTelemetry

### DIFF
--- a/go/.env.linux
+++ b/go/.env.linux
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MYSQL_DSN="my:password@tcp(localhost:3306)/db"
-MYSQL_HOST="localhost"
-MYSQL_PORT="3306"
-MYSQL_DATABASE="db"
-MYSQL_USERNAME="my"
-MYSQL_PASSWORD="password"
+export MYSQL_DSN="my:password@tcp(localhost:3306)/db"
+export MYSQL_HOST="localhost"
+export MYSQL_PORT="3306"
+export MYSQL_DATABASE="db"
+export MYSQL_USERNAME="my"
+export MYSQL_PASSWORD="password"
 
-MARIADB_DSN="my:password@tcp(localhost:3307)/db"
+export MARIADB_DSN="my:password@tcp(localhost:3307)/db"

--- a/go/.otel/collector.yaml
+++ b/go/.otel/collector.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 ADBC Drivers Contributors
+# Copyright (c) 2026 ADBC Drivers Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pixi environments
-.pixi
-*.egg-info
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
 
-generated/
-validation-report.xml
-.otel/
+processors:
+  batch:
+
+exporters:
+  file:
+    path: /otel/temp_telemetry.json
+    format: json
+    append: false
+    flush_interval: 100ms
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]

--- a/go/ci/docker/mysql-init.sql
+++ b/go/ci/docker/mysql-init.sql
@@ -1,0 +1,29 @@
+-- Copyright (c) 2026 ADBC Drivers Contributors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+INSTALL COMPONENT 'file://component_query_attributes';
+
+INSTALL COMPONENT 'file://component_telemetry'
+SET
+    PERSIST telemetry.log_enabled = ON,
+    PERSIST telemetry.metrics_enabled = ON,
+    PERSIST telemetry.trace_enabled = ON,
+    PERSIST telemetry.query_text_enabled = ON,
+    PERSIST telemetry.otel_exporter_otlp_logs_endpoint = 'http://otel-collector:4318/v1/logs',
+    PERSIST telemetry.otel_exporter_otlp_logs_protocol = 'http/protobuf',
+    PERSIST telemetry.otel_exporter_otlp_metrics_endpoint = 'http://otel-collector:4318/v1/metrics',
+    PERSIST telemetry.otel_exporter_otlp_metrics_protocol = 'http/protobuf',
+    PERSIST telemetry.otel_exporter_otlp_traces_endpoint = 'http://otel-collector:4318/v1/traces',
+    PERSIST telemetry.otel_exporter_otlp_traces_protocol = 'http/protobuf',
+    PERSIST telemetry.otel_resource_attributes = 'service.name=mysql';

--- a/go/compose.yaml
+++ b/go/compose.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 ADBC Drivers Contributors
+# Copyright (c) 2025-2026 ADBC Drivers Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
 name: mysql
 services:
   test-service:
-    image: mysql:9.4
+    image: mysql:9.7
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       MYSQL_ROOT_PASSWORD: "password"
       MYSQL_DATABASE: db
@@ -29,6 +32,17 @@ services:
       start_period: 20s
     ports:
       - 3306:3306
+    volumes:
+      - ./ci/docker/mysql-init.sql:/docker-entrypoint-initdb.d/mysql-init.sql:ro
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.156.0
+    user: "0:0"
+    command: ["--config=/otel/collector.yaml"]
+    ports:
+      - 4318:4318
+    volumes:
+      - ./.otel:/otel
 
   mariadb:
     image: mariadb:12.2

--- a/go/mysql_test.go
+++ b/go/mysql_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ADBC Drivers Contributors
+// Copyright (c) 2025-2026 ADBC Drivers Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -260,7 +260,7 @@ func (q *MySQLQuirks) GetMetadata(code adbc.InfoCode) any {
 	case adbc.InfoDriverArrowVersion:
 		return "(unknown or development build)"
 	case adbc.InfoVendorVersion:
-		return "9.4.0 (MySQL Community Server - GPL)"
+		return "9.7.1 (MySQL Community Server - GPL)"
 	case adbc.InfoVendorArrowVersion:
 		return "(unknown or development build)"
 	case adbc.InfoDriverADBCVersion:

--- a/go/validation/tests/generate_documentation.py
+++ b/go/validation/tests/generate_documentation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 ADBC Drivers Contributors
+# Copyright (c) 2025-2026 ADBC Drivers Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ from . import mysql
 
 @functools.cache
 def get_quirks(version: str, *, vendor: str) -> model.DriverQuirks:
-    if vendor == "mysql" and version == "9.4":
+    if vendor == "mysql" and version == "9.7":
         return mysql.MySQLQuirks()
     elif vendor == "mariadb" and version == "12.2":
         return mysql.MariaDBQuirks()

--- a/go/validation/tests/mysql.py
+++ b/go/validation/tests/mysql.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 ADBC Drivers Contributors
+# Copyright (c) 2025-2026 ADBC Drivers Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ class MySQLQuirks(model.DriverQuirks):
     driver = "adbc_driver_mysql"
     driver_name = "ADBC Driver Foundry Driver for MySQL"
     vendor_name = "MySQL"
-    vendor_version = "9.4.0 (MySQL Community Server - GPL)"
-    short_version = "9.4"
+    vendor_version = "9.7.1 (MySQL Community Server - GPL)"
+    short_version = "9.7"
     features = model.DriverFeatures(
         connection_get_table_schema=True,
         connection_transactions=False,


### PR DESCRIPTION
This does not actually enable OpenTelemetry in the driver, but it enables it in Docker Compose so we can set up tests down the line. It also brings us to the latest MySQL version.