### PR TITLE
feat(go): support transactions and isolation level

### DIFF
--- a/go/mysql.go
+++ b/go/mysql.go
@@ -413,6 +413,13 @@ type mysqlConnectionImpl struct {
 
 	version              string
 	zeroDatetimeBehavior zeroDatetimeBehavior
+	// activeTransaction tracks whether a BEGIN has been issued on this session
+	// (i.e. autocommit is disabled and a transaction is currently open).
+	activeTransaction bool
+	// currentIsolationLevel caches the last isolation level applied via
+	// adbc.OptionKeyIsolationLevel so GetOption can return it. Empty string
+	// means no level has been set (the session default is in effect).
+	currentIsolationLevel adbc.OptionIsolationLevel
 }
 
 // implements BulkIngester interface
@@ -423,6 +430,9 @@ var _ driverbase.CurrentNamespacer = (*mysqlConnectionImpl)(nil)
 
 // implements TableTypeLister interface
 var _ driverbase.TableTypeLister = (*mysqlConnectionImpl)(nil)
+
+// implements AutocommitSetter interface (auto-registered by sqlwrapper)
+var _ driverbase.AutocommitSetter = (*mysqlConnectionImpl)(nil)
 
 // mysqlConnectionFactory creates MySQL connections
 type mysqlConnectionFactory struct {
@@ -451,6 +461,96 @@ func (f *mysqlConnectionFactory) CreateStatement(stmt *sqlwrapper.StatementImplB
 		StatementImplBase:    stmt,
 		zeroDatetimeBehavior: stmt.Conn.Derived.(*mysqlConnectionImpl).zeroDatetimeBehavior,
 	}, nil
+}
+
+// mysqlIsolationLevelStatement maps an ADBC OptionIsolationLevel to a MySQL
+// `SET SESSION TRANSACTION ISOLATION LEVEL ...` statement. Unsupported levels
+// (SNAPSHOT, LINEARIZABLE) return StatusNotImplemented per the ADBC spec.
+func mysqlIsolationLevelStatement(l adbc.OptionIsolationLevel) (string, error) {
+	switch l {
+	case adbc.LevelDefault:
+		// MySQL's documented default isolation level is REPEATABLE READ.
+		// This mirrors the C++ PostgreSQL driver's handling of LevelDefault
+		// (which sends the backend's documented default, READ COMMITTED).
+		return "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ", nil
+	case adbc.LevelReadUncommitted:
+		return "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED", nil
+	case adbc.LevelReadCommitted:
+		return "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED", nil
+	case adbc.LevelRepeatableRead:
+		return "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ", nil
+	case adbc.LevelSerializable:
+		return "SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE", nil
+	case adbc.LevelSnapshot, adbc.LevelLinearizable:
+		return "", adbc.Error{
+			Code: adbc.StatusNotImplemented,
+			Msg:  fmt.Sprintf("[MySQL] isolation level %q not supported", string(l)),
+		}
+	default:
+		return "", adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  fmt.Sprintf("[MySQL] unknown isolation level %q", string(l)),
+		}
+	}
+}
+
+// SetAutocommit implements driverbase.AutocommitSetter. Disabling autocommit
+// begins a transaction on the dedicated session connection; enabling it
+// commits any in-flight transaction and lets subsequent statements
+// auto-commit (the MySQL default). State is mirrored by the driverbase
+// wrapper into Base().Autocommit after a successful return.
+//
+// The previously-set isolation level, if any, is already persisted at the
+// SESSION scope via `SET SESSION TRANSACTION ISOLATION LEVEL ...` in
+// SetOption, so it automatically applies to subsequent transactions without
+// any re-application here.
+func (c *mysqlConnectionImpl) SetAutocommit(ctx context.Context, enabled bool) error {
+	if enabled {
+		if c.activeTransaction {
+			if _, err := c.Conn.ExecContext(ctx, "COMMIT"); err != nil {
+				return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "COMMIT failed: %v", err)
+			}
+			c.activeTransaction = false
+		}
+		// MySQL connections auto-commit by default; nothing else to do.
+		return nil
+	}
+	// Disabling autocommit: open a transaction if one isn't already open.
+	if !c.activeTransaction {
+		if _, err := c.Conn.ExecContext(ctx, "BEGIN"); err != nil {
+			return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "BEGIN failed: %v", err)
+		}
+		c.activeTransaction = true
+	}
+	return nil
+}
+
+// Commit commits the current transaction. It is only invoked when autocommit
+// is disabled (the driverbase wrapper short-circuits to StatusInvalidState
+// otherwise). After COMMIT a new transaction is immediately begun so the
+// next statement continues to run inside a transaction until the caller
+// re-enables autocommit (chained-transaction semantics, matching the
+// Snowflake driver's pattern).
+func (c *mysqlConnectionImpl) Commit(ctx context.Context) error {
+	if _, err := c.Conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "COMMIT failed: %v", err)
+	}
+	if _, err := c.Conn.ExecContext(ctx, "BEGIN"); err != nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "BEGIN failed: %v", err)
+	}
+	return nil
+}
+
+// Rollback rolls back the current transaction. Like Commit, it begins a new
+// transaction immediately afterwards (chained-transaction semantics).
+func (c *mysqlConnectionImpl) Rollback(ctx context.Context) error {
+	if _, err := c.Conn.ExecContext(ctx, "ROLLBACK"); err != nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "ROLLBACK failed: %v", err)
+	}
+	if _, err := c.Conn.ExecContext(ctx, "BEGIN"); err != nil {
+		return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "BEGIN failed: %v", err)
+	}
+	return nil
 }
 
 type mysqlDatabase struct {
@@ -518,6 +618,8 @@ func (c *mysqlConnectionImpl) GetOption(ctx context.Context, key string) (string
 	switch key {
 	case OptionKeyZeroDatetimeBehavior:
 		return c.zeroDatetimeBehavior.String(), nil
+	case adbc.OptionKeyIsolationLevel:
+		return string(c.currentIsolationLevel), nil
 	default:
 		return c.ConnectionImplBase.GetOption(ctx, key)
 	}
@@ -531,6 +633,17 @@ func (c *mysqlConnectionImpl) SetOption(ctx context.Context, key, value string) 
 			return err
 		}
 		c.zeroDatetimeBehavior = behavior
+		return nil
+	case adbc.OptionKeyIsolationLevel:
+		level := adbc.OptionIsolationLevel(value)
+		stmt, err := mysqlIsolationLevelStatement(level)
+		if err != nil {
+			return err
+		}
+		if _, err := c.Conn.ExecContext(ctx, stmt); err != nil {
+			return c.Base().ErrorHelper.Errorf(adbc.StatusInternal, "set isolation level failed: %v", err)
+		}
+		c.currentIsolationLevel = level
 		return nil
 	default:
 		return c.ConnectionImplBase.SetOption(ctx, key, value)

--- a/go/mysql_test.go
+++ b/go/mysql_test.go
@@ -244,7 +244,7 @@ func (q *MySQLQuirks) SupportsGetSetOptions() bool                 { return true
 func (q *MySQLQuirks) SupportsGetTableSchema() bool                { return true }
 func (q *MySQLQuirks) SupportsPartitionedData() bool               { return false }
 func (q *MySQLQuirks) SupportsStatistics() bool                    { return false }
-func (q *MySQLQuirks) SupportsTransactions() bool                  { return false }
+func (q *MySQLQuirks) SupportsTransactions() bool                  { return true }
 func (q *MySQLQuirks) SupportsGetParameterSchema() bool            { return false }
 func (q *MySQLQuirks) SupportsDynamicParameterBinding() bool       { return true }
 func (q *MySQLQuirks) SupportsErrorIngestIncompatibleSchema() bool { return true }
@@ -966,6 +966,177 @@ func (s *MySQLTestSuite) TestZeroDatetimeBehaviorQuery() {
 
 	s.False(rdr.Next())
 	s.NoError(rdr.Err())
+}
+
+// TestTransactions verifies that disabling autocommit and using Commit/Rollback
+// produces the expected session-level transaction semantics. The cnxn is shared
+// with the rest of MySQLTestSuite, so we restore autocommit to enabled in a
+// defer and clean up any test tables.
+func (s *MySQLTestSuite) TestTransactions() {
+	cnxnOpts, ok := s.cnxn.(adbc.GetSetOptionsWithContext)
+	s.Require().Truef(ok, "expected connection to implement GetSetOptionsWithContext")
+
+	// Save the initial autocommit state (expected: enabled per SetupSuite)
+	initialAC, err := cnxnOpts.GetOption(s.ctx, adbc.OptionKeyAutoCommit)
+	s.Require().NoError(err)
+
+	// Always restore autocommit at the end so other suite tests see
+	// default state.
+	defer func() {
+		_ = cnxnOpts.SetOption(s.ctx, adbc.OptionKeyAutoCommit, adbc.OptionValueEnabled)
+		_ = s.stmt.SetSqlQuery(s.ctx, "DROP TABLE IF EXISTS `adbc_tx_test`")
+		_, _ = s.stmt.ExecuteUpdate(s.ctx)
+	}()
+
+	// Clean slate
+	s.NoError(s.stmt.SetSqlQuery(s.ctx, "DROP TABLE IF EXISTS `adbc_tx_test`"))
+	_, err = s.stmt.ExecuteUpdate(s.ctx)
+	s.Require().NoError(err)
+
+	s.NoError(s.stmt.SetSqlQuery(s.ctx, "CREATE TABLE `adbc_tx_test` (id INT NOT NULL)"))
+	_, err = s.stmt.ExecuteUpdate(s.ctx)
+	s.Require().NoError(err)
+
+	countRows := func() int64 {
+		s.NoError(s.stmt.SetSqlQuery(s.ctx, "SELECT COUNT(*) FROM `adbc_tx_test`"))
+		rdr, _, err := s.stmt.ExecuteQuery(s.ctx)
+		s.Require().NoError(err)
+		defer rdr.Release()
+		s.True(rdr.Next())
+		rec := rdr.RecordBatch()
+		s.Require().EqualValues(1, rec.NumRows())
+		return rec.Column(0).(*array.Int64).Value(0)
+	}
+
+	// --- Rollback path ---
+	s.NoError(cnxnOpts.SetOption(s.ctx, adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+	s.NoError(s.stmt.SetSqlQuery(s.ctx, "INSERT INTO `adbc_tx_test` (id) VALUES (1)"))
+	_, err = s.stmt.ExecuteUpdate(s.ctx)
+	s.Require().NoError(err)
+	s.EqualValues(1, countRows(), "row should be visible within the transaction")
+	s.NoError(s.cnxn.Rollback(s.ctx))
+	s.EqualValues(0, countRows(), "rollback should have discarded the insert")
+
+	// --- Commit path ---
+	s.NoError(s.stmt.SetSqlQuery(s.ctx, "INSERT INTO `adbc_tx_test` (id) VALUES (2)"))
+	_, err = s.stmt.ExecuteUpdate(s.ctx)
+	s.Require().NoError(err)
+	s.EqualValues(1, countRows(), "row should be visible within the transaction")
+	s.NoError(s.cnxn.Commit(s.ctx))
+	// After Commit, chained-transaction semantics mean a new tx is open;
+	// the committed row is now durable and (after re-enabling ac) visible.
+	s.NoError(cnxnOpts.SetOption(s.ctx, adbc.OptionKeyAutoCommit, adbc.OptionValueEnabled))
+	s.EqualValues(1, countRows(), "committed row should be visible after re-enabling autocommit")
+
+	// --- Re-enabling autocommit returns the cached flag ---
+	currentAC, err := cnxnOpts.GetOption(s.ctx, adbc.OptionKeyAutoCommit)
+	s.Require().NoError(err)
+	s.Equal(adbc.OptionValueEnabled, currentAC)
+	_ = initialAC // suppress unused-variable; kept for clarity
+}
+
+// TestIsolationLevels verifies that supported ADBC isolation levels round-trip
+// to MySQL's session transaction_isolation variable, and that unsupported /
+// unknown levels produce the expected ADBC error codes.
+func (s *MySQLTestSuite) TestIsolationLevels() {
+	cnxnOpts, ok := s.cnxn.(adbc.GetSetOptionsWithContext)
+	s.Require().Truef(ok, "expected connection to implement GetSetOptionsWithContext")
+
+	supportedCases := []struct {
+		level    adbc.OptionIsolationLevel
+		expected string // value returned by @@SESSION.transaction_isolation
+	}{
+		{adbc.LevelReadUncommitted, "READ-UNCOMMITTED"},
+		{adbc.LevelReadCommitted, "READ-COMMITTED"},
+		{adbc.LevelRepeatableRead, "REPEATABLE-READ"},
+		{adbc.LevelSerializable, "SERIALIZABLE"},
+		{adbc.LevelDefault, "REPEATABLE-READ"}, // MySQL's documented default
+	}
+
+	// Capture the session's starting isolation level so we can restore it.
+	s.NoError(s.stmt.SetSqlQuery(s.ctx, "SELECT @@SESSION.transaction_isolation"))
+	rdr, _, err := s.stmt.ExecuteQuery(s.ctx)
+	s.Require().NoError(err)
+	rdr.Next()
+	initialLevel := rdr.RecordBatch().Column(0).(*array.String).Value(0)
+	rdr.Release()
+
+	defer func() {
+		// Restore the server session default by issuing an explicit SET SESSION
+		s.NoError(s.stmt.SetSqlQuery(s.ctx,
+			fmt.Sprintf("SET SESSION TRANSACTION ISOLATION LEVEL %s", initialLevel)))
+		_, _ = s.stmt.ExecuteUpdate(s.ctx)
+	}()
+
+	for _, tc := range supportedCases {
+		s.Run(string(tc.level), func() {
+			s.NoError(cnxnOpts.SetOption(s.ctx, adbc.OptionKeyIsolationLevel, string(tc.level)))
+			s.NoError(s.stmt.SetSqlQuery(s.ctx, "SELECT @@SESSION.transaction_isolation"))
+			rdr, _, err := s.stmt.ExecuteQuery(s.ctx)
+			s.Require().NoError(err)
+			defer rdr.Release()
+			s.True(rdr.Next())
+			got := rdr.RecordBatch().Column(0).(*array.String).Value(0)
+			s.Equal(tc.expected, got, "isolation level %s", tc.level)
+		})
+	}
+
+	// Unsupported levels return StatusNotImplemented per the ADBC spec.
+	for _, level := range []adbc.OptionIsolationLevel{adbc.LevelSnapshot, adbc.LevelLinearizable} {
+		s.Run("unsupported_"+string(level), func() {
+			err := cnxnOpts.SetOption(s.ctx, adbc.OptionKeyIsolationLevel, string(level))
+			s.Require().Error(err)
+			var adbcErr adbc.Error
+			s.Require().Truef(errors.As(err, &adbcErr), "expected ADBC error, got %T: %v", err, err)
+			s.Equal(adbc.StatusNotImplemented, adbcErr.Code)
+		})
+	}
+
+	// An unknown level value returns StatusInvalidArgument.
+	s.Run("unknown_level", func() {
+		err := cnxnOpts.SetOption(s.ctx, adbc.OptionKeyIsolationLevel, "adbc.connection.transaction.isolation.bogus")
+		s.Require().Error(err)
+		var adbcErr adbc.Error
+		s.Require().Truef(errors.As(err, &adbcErr), "expected ADBC error, got %T: %v", err, err)
+		s.Equal(adbc.StatusInvalidArgument, adbcErr.Code)
+	})
+}
+
+// TestIsolationLevelGetOption verifies that the last-set isolation level can
+// be read back via GetOption(OptionKeyIsolationLevel).
+func (s *MySQLTestSuite) TestIsolationLevelGetOption() {
+	cnxnOpts, ok := s.cnxn.(adbc.GetSetOptionsWithContext)
+	s.Require().Truef(ok, "expected connection to implement GetSetOptionsWithContext")
+
+	// Capture whatever level is currently cached so we can restore it.
+	initial, err := cnxnOpts.GetOption(s.ctx, adbc.OptionKeyIsolationLevel)
+	s.Require().NoError(err)
+
+	defer func() {
+		// Best-effort restore. We only set if the initial value was non-empty;
+		// an empty cache means "never set" and we leave that state by issuing a
+		// known-safe level (MySQL default) so subsequent tests are deterministic.
+		if initial != "" {
+			_ = cnxnOpts.SetOption(s.ctx, adbc.OptionKeyIsolationLevel, initial)
+		} else {
+			_ = cnxnOpts.SetOption(s.ctx, adbc.OptionKeyIsolationLevel, string(adbc.LevelDefault))
+			// Now reset the cache to empty by reading GetOption (we can't
+			// directly clear; the empty-string behaviour is approximated).
+		}
+	}()
+
+	for _, level := range []adbc.OptionIsolationLevel{
+		adbc.LevelReadCommitted,
+		adbc.LevelSerializable,
+		adbc.LevelRepeatableRead,
+	} {
+		s.Run(string(level), func() {
+			s.NoError(cnxnOpts.SetOption(s.ctx, adbc.OptionKeyIsolationLevel, string(level)))
+			got, err := cnxnOpts.GetOption(s.ctx, adbc.OptionKeyIsolationLevel)
+			s.Require().NoError(err)
+			s.Equal(string(level), got)
+		})
+	}
 }
 
 func TestMySQLTypeTests(t *testing.T) {

--- a/go/validation/pytest.ini
+++ b/go/validation/pytest.ini
@@ -24,4 +24,3 @@ markers =
 filterwarnings =
     error
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning
-    ignore:Cannot disable autocommit; conn will not be DB-API 2.0 compliant:adbc_driver_manager._lib.Warning

--- a/go/validation/tests/mysql.py
+++ b/go/validation/tests/mysql.py
@@ -27,7 +27,7 @@ class MySQLQuirks(model.DriverQuirks):
     short_version = "9.7"
     features = model.DriverFeatures(
         connection_get_table_schema=True,
-        connection_transactions=False,
+        connection_transactions=True,
         get_objects=True,
         get_objects_constraints_foreign=False,
         get_objects_constraints_primary=False,


### PR DESCRIPTION
## What's Changed

Implement transaction support (autocommit toggle, Commit, Rollback) and
isolation-level support for the MySQL ADBC driver.

- `mysqlConnectionImpl` now implements `driverbase.AutocommitSetter`
  (auto-registered by sqlwrapper via type assertion): `SetAutocommit(false)`
  issues `BEGIN`; `SetAutocommit(true)` issues `COMMIT`. The driverbase
  wrapper still short-circuits Commit/Rollback to `StatusInvalidState`
  when autocommit is enabled.
- `Commit`/`Rollback` use chained-transaction semantics (COMMIT then
  BEGIN) so the next statement continues to run inside a transaction
  until the caller re-enables autocommit — matches the Snowflake driver's
  pattern (`snowflake/go/connection.go:800-826`).
- `OptionKeyIsolationLevel` is translated to
  `SET SESSION TRANSACTION ISOLATION LEVEL ...` and applied immediately.
  `LevelDefault` maps to `REPEATABLE READ` (MySQL's documented default
  and the same convention the C++ PostgreSQL driver uses at
  `arrow-adbc/c/driver/postgresql/connection.cc:1215`). `LevelSnapshot`
  and `LevelLinearizable` are not supported and return
  `StatusNotImplemented` per ADBC spec.
- `GetOption(OptionKeyIsolationLevel)` returns the cached level.
- `SupportsTransactions` capability flag flipped to `true` in both Go
  quirks (`mysql_test.go`) and Python validation
  (`validation/tests/mysql.py`).
- Removed obsolete `pytest.ini` filter that suppressed
  `"Cannot disable autocommit; conn will not be DB-API 2.0 compliant"`
  warnings — no longer triggered now that autocommit toggling works.
- Added integration tests covering transaction commit/rollback durability
  and isolation-level round-trips against a live MySQL server.

Closes #55.
Closes #34.